### PR TITLE
SELC-3035 Create group is no longer bound by the active product

### DIFF
--- a/src/pages/dashboardGroupEdit/components/GroupForm.tsx
+++ b/src/pages/dashboardGroupEdit/components/GroupForm.tsx
@@ -155,10 +155,7 @@ function GroupForm({
 
   useEffect(() => {
     const enabledProducts = products.filter((p) =>
-      party.products.some(
-        (pp) =>
-          p.id === pp.productId && pp.authorized && pp.userRole === 'ADMIN' && p.status === 'ACTIVE'
-      )
+      party.products.some((pp) => p.id === pp.productId && pp.authorized && pp.userRole === 'ADMIN')
     );
     setProductInPage((isClone || isAddPage) && Object.keys(enabledProducts).length === 1);
     if (productInPage) {

--- a/src/pages/dashboardGroupEdit/components/GroupForm.tsx
+++ b/src/pages/dashboardGroupEdit/components/GroupForm.tsx
@@ -114,13 +114,14 @@ function GroupForm({
 
   const history = useHistory();
 
+  const { registerUnloadEvent, unregisterUnloadEvent } = useUnloadEventInterceptor();
+  const onExit = useUnloadEventOnExit();
+
   const [productSelected, setProductSelected] = useState<Product>();
   const [productUsers, setProductUsers] = useState<Array<PartyProductUser>>([]);
   const [automaticRemove, setAutomaticRemove] = useState(false);
   const [isNameDuplicated, setIsNameDuplicated] = useState(false);
   const [productInPage, setProductInPage] = useState<boolean>();
-  const { registerUnloadEvent, unregisterUnloadEvent } = useUnloadEventInterceptor();
-  const onExit = useUnloadEventOnExit();
 
   const isEdit = !!(initialFormData as PartyGroupOnEdit).id;
   const prodPnpg = products.find((p) => p.id === 'prod-pn-pg');


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Create group is no longer bound by the active product

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In the group creation, modification and duplication form, the product selection was also limited by active status but we allow to create group also for product in status testing for example, provided that you are admin, authorized and the product is boarded

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
With local data
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.