### PR TITLE
[SELC-2150] feat: Show all CTA in groups based on onboardingStatus being active

### DIFF
--- a/src/pages/dashboardGroupDetail/GroupDetailPage.tsx
+++ b/src/pages/dashboardGroupDetail/GroupDetailPage.tsx
@@ -62,7 +62,7 @@ function GroupDetailPage({ partyGroup, party, productsMap, productsRolesMap }: P
 
   const product = productsMap[partyGroupState.productId];
   const canEdit = !!party.products.find(
-    (pp) => pp.productId === product.id && pp.userRole === 'ADMIN' && product.status === 'ACTIVE'
+    (pp) => pp.productId === product.id && pp.userRole === 'ADMIN' && pp.productOnBoardingStatus === 'ACTIVE'
   );
 
   const isSuspended = partyGroupState.status === 'SUSPENDED';

--- a/src/remotes/__tests__/RoutingGroups.test.tsx
+++ b/src/remotes/__tests__/RoutingGroups.test.tsx
@@ -75,6 +75,28 @@ test('test routing clone group from group detail', async () => {
   await toVerifyPath('/dashboard/onboarded/groups/groupId1/clone', 'Duplica gruppo', history);
 });
 
+test('suspend group button should be visible and open suspend modal', async () => {
+  const { history } = renderComponent();
+  await toVerifyPath('/dashboard/onboarded/groups/groupId1', 'Dettaglio Gruppo', history);
+  const suspendButton = screen.getByText('Sospendi');
+  await waitFor(() => fireEvent.click(suspendButton));
+  const suspendModalTitle = await screen.findByText('Sospendi gruppo');
+  expect(suspendModalTitle).toBeInTheDocument();
+  const closeModalButton = await screen.findByText('Annulla');
+  await waitFor(() => fireEvent.click(closeModalButton));
+});
+
+test('delete group button should be visible and open delete modal', async () => {
+  const { history } = renderComponent();
+  await toVerifyPath('/dashboard/onboarded/groups/groupId1', 'Dettaglio Gruppo', history);
+  const deleteButton = screen.getByText('Elimina');
+  await waitFor(() => fireEvent.click(deleteButton));
+  const deleteModalTitle = await screen.findByText('Elimina gruppo');
+  expect(deleteModalTitle).toBeInTheDocument();
+  const closeModalButton = await screen.findByText('Annulla');
+  await waitFor(() => fireEvent.click(closeModalButton));
+});
+
 test('test routing add new group', async () => {
   const { history } = renderComponent();
   await toVerifyPath('/dashboard/onboarded/groups/add', 'Crea un nuovo gruppo', history);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Implemented a control mechanism to check the onboardingStatus for groups on the Dashboard. This enhancement ensures that all Calls to Action (CTAs) associated with groups are correctly displayed.
<!--- Describe your changes in detail -->

#### Motivation and Context
The motivation behind this change is to address the current issue where not all CTAs for groups are being displayed on the Dashboard. By introducing a control that checks the onboardingStatus and verifies that it is set to "Active," we can guarantee a consistent and accurate representation of group-related CTAs.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested on  dev inviroment by creating a groupon on a product with status = "Testing"
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.