### PR TITLE
[SELC-6511] fix: remove empty border space

### DIFF
--- a/src/pages/dashboardGroupEdit/components/GroupForm.tsx
+++ b/src/pages/dashboardGroupEdit/components/GroupForm.tsx
@@ -468,7 +468,6 @@ function GroupForm({
                 disabled={isEdit || productInPage}
                 fullWidth
                 value={productSelected?.title ?? ''}
-                displayEmpty
                 variant="outlined"
                 labelId="select-label-products"
                 label={t('dashboardGroupEdit.groupForm.formLabels.productPlaceholder')}
@@ -530,7 +529,6 @@ function GroupForm({
               size="small"
               disabled={!productSelected}
               multiple
-              displayEmpty
               fullWidth
               label={t('dashboardGroupEdit.groupForm.formLabels.referentsPlaceholder')}
               labelId="select-label-members"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Removed displayEmpty property from Select
<!--- Describe your changes in detail -->

#### Motivation and Context
The border was partially empty empty when no value selected.
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.