### PR TITLE
[SELC-7627] feat: admin ea can not check user members details without action  ListProductUsers

### DIFF
--- a/src/pages/dashboardGroupDetail/components/MembersGroup.tsx
+++ b/src/pages/dashboardGroupDetail/components/MembersGroup.tsx
@@ -1,7 +1,12 @@
 import { Box, Button, Grid, Link, Paper, Tooltip, Typography } from '@mui/material';
 import { DataGrid, GridRenderCellParams, GridRow } from '@mui/x-data-grid';
 import { theme } from '@pagopa/mui-italia';
-import { roleLabels, UserRole } from '@pagopa/selfcare-common-frontend/lib/utils/constants';
+import { usePermissions } from '@pagopa/selfcare-common-frontend/lib';
+import {
+  Actions,
+  roleLabels,
+  UserRole,
+} from '@pagopa/selfcare-common-frontend/lib/utils/constants';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/lib/utils/routes-utils';
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -44,6 +49,8 @@ export default function MembersGroup({
   const isMobile = useIsMobile('lg');
 
   const [members, setMembers] = useState<Array<PartyProductUser>>([]);
+  const { hasPermission } = usePermissions();
+  const canViewUserDetails = hasPermission(product.id, Actions.ListProductUsers);
 
   const rowHeight = isMobile ? 250 : 64;
   const headerHeight = isMobile ? 10 : 56;
@@ -85,12 +92,12 @@ export default function MembersGroup({
       renderCell: (member: GridRenderCellParams<any, any, any>) => (
         <Link
           component="button"
-          disabled={isSuspended}
+          disabled={isSuspended || !canViewUserDetails}
           sx={{
             width: '100%',
             textDecoration: 'none',
             fontWeight: 'fontWeightMedium',
-            cursor: isSuspended ? 'text' : 'pointer',
+            cursor: isSuspended || !canViewUserDetails ? 'text' : 'pointer',
             display: 'flex',
           }}
           onClick={() =>
@@ -118,7 +125,11 @@ export default function MembersGroup({
                 pl: 1,
                 fontSize: 'fontSize',
                 fontWeight: 'fontWeightMedium',
-                color: isSuspended ? 'text.disabled' : 'primary.main',
+                color: isSuspended
+                  ? 'text.disabled'
+                  : !canViewUserDetails
+                    ? 'undefined'
+                    : 'primary.main',
                 justifyContent: 'flexStart',
               }}
             >


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add hasPermission for  Actions.ListProductUsers
name of user not clickable for admi ea
<!--- Describe your changes in detail -->

#### Motivation and Context
Admin EA can not see users section. Disabled link to users section for admin EA
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.