### PR TITLE
[SELC-8990] feat: exclude specific users from group assignments for prod-io and add helper text support

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Create Release Branch
         id: create_branch
-        uses: pagopa/selfcare-commons/github-actions-template/create-release@main
+        uses: pagopa/selfcare/.github/actions/create-release@main
         with:
           version_bump: ${{ inputs.version-bump }}
           github_path_token: ${{ secrets.GH_PAT_VARIABLES }}

--- a/.github/workflows/deploy_cdn.yml
+++ b/.github/workflows/deploy_cdn.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release_and_deploy:
-    uses: pagopa/selfcare-commons/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
+    uses: pagopa/selfcare/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
     name: "Release [${{ inputs.env != null && inputs.env || (startsWith(github.ref_name, 'releases/') && 'uat') || 'dev' }}]"
     secrets: inherit
     with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [release_and_deploy]
     steps:
-      - uses: pagopa/selfcare-commons/github-actions-template/promote-release@main
+      - uses: pagopa/selfcare/.github/actions/promote-release@main
         with:
           github_path_token: ${{ secrets.GH_PAT_VARIABLES }}
           release_version: ${{ vars.CURRENT_UAT_VERSION }}

--- a/.github/workflows/deploy_cdn_pnpg.yml
+++ b/.github/workflows/deploy_cdn_pnpg.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release_and_deploy:
-    uses: pagopa/selfcare-commons/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
+    uses: pagopa/selfcare/.github/workflows/call_release_cdn_vite_frontdoor.yml@main
     name: "Release [${{ (github.event_name == 'workflow_dispatch' && inputs.env) || (startsWith(github.ref_name, 'releases/') && 'uat') || 'dev' }}]"
     secrets: inherit
     with:

--- a/openApi/dashboard-api-docs.json
+++ b/openApi/dashboard-api-docs.json
@@ -1,23 +1,12 @@
 {
   "openapi" : "3.0.1",
   "info" : {
-    "title" : "${openapi_title}",
+    "title" : "Dashboard BFF API",
     "description" : "Self Care Dashboard API documentation",
     "version" : "0.0.1-SNAPSHOT"
   },
   "servers" : [ {
-    "url" : "{url}:{port}{basePath}",
-    "variables" : {
-      "url" : {
-        "default" : "http://localhost"
-      },
-      "port" : {
-        "default" : "80"
-      },
-      "basePath" : {
-        "default" : ""
-      }
-    }
+    "url" : "http://localhost:80"
   } ],
   "tags" : [ {
     "name" : "delegations",
@@ -1560,6 +1549,69 @@
         } ]
       }
     },
+    "/v2/users/otp-info" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "getUserOtpEmailInfo",
+        "description" : "Service to get the otp info for the current user",
+        "operationId" : "getUserOtpEmailInfoUsingGET",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserOtpEmailInfo"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v2/users/institution/{institutionId}" : {
       "get" : {
         "tags" : [ "user" ],
@@ -1612,6 +1664,109 @@
                   "type" : "array",
                   "items" : {
                     "$ref" : "#/components/schemas/ProductUserResource"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v2/users/all/institution/{institutionId}" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "getAllUsers",
+        "description" : "Service to get all the users related to a specific institution",
+        "operationId" : "v2GetAllUsersUsingGET",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "description" : "Institution's unique internal identifier",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "description" : "productId",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "states",
+          "in" : "query",
+          "description" : "states",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "roles",
+          "in" : "query",
+          "description" : "roles",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/UserInstitutionRole"
                   }
                 }
               }
@@ -3089,6 +3244,158 @@
         } ]
       }
     },
+    "/v2/institutions/all/{institutionId}" : {
+      "get" : {
+        "tags" : [ "institutions" ],
+        "summary" : "Service to get a specific institution in ARB",
+        "description" : "Service to get a specific institution in ARB",
+        "operationId" : "v2GetAllInstitution",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "description" : "Institution's unique internal identifier",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InstitutionResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v2/institutions/all/{institutionId}/users/{userId}" : {
+      "get" : {
+        "tags" : [ "institutions" ],
+        "summary" : "getAllInstitutionUser",
+        "description" : "Service to get the users with the given user id related to a specific institution even without a role on the institution",
+        "operationId" : "v2RetrieveAllInstitutionUser",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "description" : "Institution's unique internal identifier",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "userId",
+          "in" : "path",
+          "description" : "User's unique identifier",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InstitutionUserDetailsResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v1/products/{productId}/roles" : {
       "get" : {
         "tags" : [ "products" ],
@@ -3205,6 +3512,69 @@
                   "items" : {
                     "$ref" : "#/components/schemas/BrokerResource"
                   }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v1/products/my-permissions" : {
+      "get" : {
+        "tags" : [ "products" ],
+        "summary" : "Service to retrieve the logged user's permissions for all products",
+        "description" : "Service to retrieve the logged user's permissions for all products",
+        "operationId" : "getMyPermissions",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProductRolePermissionsList"
                 }
               }
             }
@@ -3720,7 +4090,7 @@
         "properties" : {
           "role" : {
             "type" : "string",
-            "description" : "User's role, available values: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]"
+            "description" : "User's role, available values: [MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA]"
           },
           "productRoles" : {
             "uniqueItems" : true,
@@ -4143,7 +4513,7 @@
           },
           "role" : {
             "type" : "string",
-            "description" : "User's role, available values: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]"
+            "description" : "User's role, available values: [MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA]"
           },
           "productRoles" : {
             "uniqueItems" : true,
@@ -4259,6 +4629,23 @@
           }
         }
       },
+      "UserOtpEmailInfo" : {
+        "type" : "object",
+        "properties" : {
+          "userId" : {
+            "type" : "string"
+          },
+          "otpEmail" : {
+            "type" : "string"
+          },
+          "otpReferenceInstitutionId" : {
+            "type" : "string"
+          },
+          "canUserChangeOtpEmail" : {
+            "type" : "boolean"
+          }
+        }
+      },
       "ProductInfoResource" : {
         "type" : "object",
         "properties" : {
@@ -4299,6 +4686,24 @@
             "type" : "string",
             "description" : "User's Selfcare role, available values: [ADMIN, ADMIN_EA, LIMITED]",
             "enum" : [ "ADMIN", "LIMITED", "ADMIN_EA" ]
+          },
+          "partyRole" : {
+            "type" : "string",
+            "description" : "User's role, available values: [MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA]"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "description" : "User's role creation date associated with a product",
+            "format" : "date-time"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "description" : "User's role last update date",
+            "format" : "date-time"
+          },
+          "excludeRoleFromUserGroups" : {
+            "type" : "boolean",
+            "description" : "Boolean indicating if the current product role should be excluded from the user groups"
           }
         },
         "description" : "User's role infos in product"
@@ -4341,8 +4746,34 @@
           },
           "createdAt" : {
             "type" : "string",
-            "description" : "User's creation date associated with a product",
+            "description" : "User's role creation date associated with a product",
             "format" : "date-time"
+          }
+        }
+      },
+      "UserInstitutionRole" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "surname" : {
+            "type" : "string"
+          },
+          "fiscalCode" : {
+            "type" : "string"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "partyRole" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
           }
         }
       },
@@ -4766,7 +5197,7 @@
           },
           "role" : {
             "type" : "string",
-            "description" : "User's role, available values: [MANAGER, DELEGATE, SUBDELEGATE, OPERATOR, ADMIN_EA]",
+            "description" : "User's role, available values: [MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA]",
             "enum" : [ "ADMIN", "LIMITED", "ADMIN_EA" ]
           },
           "status" : {
@@ -4959,10 +5390,6 @@
             "description" : "Self Care role",
             "enum" : [ "ADMIN", "LIMITED", "ADMIN_EA" ]
           },
-          "multiroleAllowed" : {
-            "type" : "boolean",
-            "description" : "Indicates if an User can have more than one product role"
-          },
           "phasesAdditionAllowed" : {
             "type" : "array",
             "description" : "List of phases where addition of the role is allowed",
@@ -4994,6 +5421,14 @@
           "description" : {
             "type" : "string",
             "description" : "Product role description"
+          },
+          "multiroleGroups" : {
+            "type" : "array",
+            "description" : "Product role groups that allow to assign multiple roles to the same user",
+            "items" : {
+              "type" : "string",
+              "description" : "Product role groups that allow to assign multiple roles to the same user"
+            }
           }
         },
         "description" : "Available product roles"
@@ -5012,6 +5447,52 @@
           "enabled" : {
             "type" : "boolean",
             "description" : "Partner's enabling"
+          }
+        }
+      },
+      "ProductRolePermissions" : {
+        "type" : "object",
+        "properties" : {
+          "productId" : {
+            "type" : "string"
+          },
+          "role" : {
+            "type" : "string"
+          },
+          "group" : {
+            "type" : "string"
+          },
+          "permissions" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "ProductRolePermissionsList" : {
+        "type" : "object",
+        "properties" : {
+          "userId" : {
+            "type" : "string"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "familyName" : {
+            "type" : "string"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ProductRolePermissions"
+            }
           }
         }
       },

--- a/src/api/__mocks__/DashboardApiClient.ts
+++ b/src/api/__mocks__/DashboardApiClient.ts
@@ -78,6 +78,7 @@ export const mockedProductUserResource: Array<ProductUserResource> = [
           role: 'incaricato-ente-creditore',
           selcRole: SelcRoleEnum.ADMIN,
           status: 'ACTIVE',
+          excludeRoleFromUserGroups: true,
         },
       ],
     },

--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -174,6 +174,7 @@ export default {
         descriptionMaxLength: 'Max. 200 Zeichen',
         noProductSelected: 'Kein Produkt gewählt',
         referentsPlaceholder: 'Wähle die Benutzer, die du mit der Gruppe verknüpfen möchtest',
+        excludedUsersHelperText: 'Hier finden Sie nur die Benutzer, die Sie der Gruppe zuordnen können. Die Benutzer einer Aggregatoreinrichtung sind bereits Teil einer dedizierten Gruppe.',
         cancelActionLabel: 'Zurück',
         confirmActionLabel: 'Bestätigen',
       },

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -172,6 +172,7 @@ export default {
         descriptionMaxLength: 'Max 200 characters',
         noProductSelected: 'No product selected',
         referentsPlaceholder: 'Select the users you want to associate with the group',
+        excludedUsersHelperText: 'Here you will find only the users you can associate with the group. The users of an aggregator entity are already part of a dedicated group.',
         cancelActionLabel: 'Go back',
         confirmActionLabel: 'Confirm',
       },

--- a/src/locale/fr.ts
+++ b/src/locale/fr.ts
@@ -175,6 +175,7 @@ export default {
         descriptionMaxLength: '200 caractères maximu.',
         noProductSelected: 'Aucun produit sélectionné',
         referentsPlaceholder: 'Sélectionnez les utilisateurs que vous souhaitez associer au groupe',
+        excludedUsersHelperText: 'Vous ne trouverez ici que les utilisateurs que vous pouvez associer au groupe. Les utilisateurs d\'une entité agrégatrice font déjà partie d\'un groupe dédié.',
         cancelActionLabel: 'Retour',
         confirmActionLabel: 'Confirmer',
       },

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -168,6 +168,7 @@ export default {
         descriptionMaxLength: 'Max 200 caratteri',
         noProductSelected: 'Nessun prodotto selezionato',
         referentsPlaceholder: 'Seleziona gli utenti che vuoi associare al gruppo',
+        excludedUsersHelperText: 'Qui trovi solo gli utenti che puoi associare al gruppo. Gli utenti di un ente aggregatore fanno già parte di un gruppo dedicato.',
         cancelActionLabel: 'Indietro',
         confirmActionLabel: 'Conferma',
       },

--- a/src/locale/sl.ts
+++ b/src/locale/sl.ts
@@ -172,6 +172,7 @@ export default {
         descriptionMaxLength: 'Največ 200 znakov',
         noProductSelected: 'Izbran ni noben produkt',
         referentsPlaceholder: 'Izberite uporabnike, ki jih želite povezati s skupino',
+        excludedUsersHelperText: 'Tukaj boste našli le uporabnike, ki jih lahko povežete s skupino. Uporabniki agregatorskega subjekta so že del namenske skupine.',
         cancelActionLabel: 'Nazaj',
         confirmActionLabel: 'Potrdi',
       },

--- a/src/model/PartyUser.ts
+++ b/src/model/PartyUser.ts
@@ -74,5 +74,6 @@ export const productInfoResource2PartyUserProduct = (
     role: r.role,
     selcRole: r.selcRole as UserRole,
     status: r.status as UserStatus,
+    excludeRoleFromUserGroups: r.excludeRoleFromUserGroups,
   })) as Array<PartyUserProductRole>,
 });

--- a/src/model/PartyUser.ts
+++ b/src/model/PartyUser.ts
@@ -13,6 +13,7 @@ export type BasePartyUser = {
   userRole: UserRole;
   status: UserStatus;
   isCurrentUser: boolean;
+  excludeRoleFromUserGroups?: boolean;
 };
 
 export type PartyProductUser = BasePartyUser & {
@@ -59,6 +60,7 @@ export const productUserResource2PartyProductUser = (
   product: productInfoResource2PartyUserProduct(product, resource?.product),
   status: resource.status as UserStatus,
   isCurrentUser: currentUser.uid === resource.id,
+  excludeRoleFromUserGroups: (resource as any).excludeRoleFromUserGroups,
 });
 
 export const productInfoResource2PartyUserProduct = (

--- a/src/model/PartyUser.ts
+++ b/src/model/PartyUser.ts
@@ -45,6 +45,7 @@ export type PartyUserProductRole = {
   role: string;
   selcRole: UserRole;
   status: UserStatus;
+  excludeRoleFromUserGroups?: boolean;
 };
 
 export const productUserResource2PartyProductUser = (

--- a/src/model/PartyUser.ts
+++ b/src/model/PartyUser.ts
@@ -52,17 +52,21 @@ export const productUserResource2PartyProductUser = (
   resource: ProductUserResource,
   product: Product,
   currentUser: User
-): PartyProductUser => ({
-  id: resource.id ?? '',
-  name: resource.name ?? '',
-  surname: resource.surname ?? '',
-  email: resource?.email as EmailString,
-  userRole: resource.role as UserRole,
-  product: productInfoResource2PartyUserProduct(product, resource?.product),
-  status: resource.status as UserStatus,
-  isCurrentUser: currentUser.uid === resource.id,
-  excludeRoleFromUserGroups: (resource as any).excludeRoleFromUserGroups,
-});
+): PartyProductUser => {
+  const partyProduct = productInfoResource2PartyUserProduct(product, resource?.product);
+  
+  return {
+    id: resource.id ?? '',
+    name: resource.name ?? '',
+    surname: resource.surname ?? '',
+    email: resource?.email as EmailString,
+    userRole: resource.role as UserRole,
+    product: partyProduct,
+    status: resource.status as UserStatus,
+    isCurrentUser: currentUser.uid === resource.id,
+    excludeRoleFromUserGroups: partyProduct.roles?.some((r) => r.excludeRoleFromUserGroups) ?? false,
+  };
+};
 
 export const productInfoResource2PartyUserProduct = (
   product: Product,

--- a/src/model/__tests__/PartyGroup.test.ts
+++ b/src/model/__tests__/PartyGroup.test.ts
@@ -52,6 +52,7 @@ test('Test usersGroupResource2PartyGroupDetail', () => {
               role: 'ADMIN',
               selcRole: 'ADMIN',
               status: 'ACTIVE',
+              excludeRoleFromUserGroups: undefined,
             },
           ],
           title: 'App IO',

--- a/src/model/__tests__/PartyGroup.test.ts
+++ b/src/model/__tests__/PartyGroup.test.ts
@@ -42,6 +42,7 @@ test('Test usersGroupResource2PartyGroupDetail', () => {
         email: 'address',
         id: '1',
         isCurrentUser: false,
+        excludeRoleFromUserGroups: undefined,
         name: 'Name',
         product: {
           id: 'productId',

--- a/src/model/__tests__/PartyGroup.test.ts
+++ b/src/model/__tests__/PartyGroup.test.ts
@@ -42,7 +42,7 @@ test('Test usersGroupResource2PartyGroupDetail', () => {
         email: 'address',
         id: '1',
         isCurrentUser: false,
-        excludeRoleFromUserGroups: undefined,
+        excludeRoleFromUserGroups: false,
         name: 'Name',
         product: {
           id: 'productId',

--- a/src/model/__tests__/PartyUser.test.ts
+++ b/src/model/__tests__/PartyUser.test.ts
@@ -22,6 +22,7 @@ test('Test productUserResource2PartyUser', () => {
           role: 'productRole',
           selcRole: SelcRoleEnum.ADMIN,
           status: 'ACTIVE',
+          excludeRoleFromUserGroups: true,
         },
       ],
     },
@@ -39,6 +40,7 @@ test('Test productUserResource2PartyUser', () => {
     status: 'PENDING',
     userRole: 'LIMITED',
     email: 'address',
+    excludeRoleFromUserGroups: undefined,
     product: {
       id: 'productId',
       title: 'productTitle',
@@ -48,11 +50,11 @@ test('Test productUserResource2PartyUser', () => {
           role: 'productRole',
           selcRole: 'ADMIN',
           status: 'ACTIVE',
+          excludeRoleFromUserGroups: true,
         },
       ],
     },
     isCurrentUser: false,
-    excludeRoleFromUserGroups: undefined,
   });
 
   productUserResource.id = mockedUser.uid;

--- a/src/model/__tests__/PartyUser.test.ts
+++ b/src/model/__tests__/PartyUser.test.ts
@@ -40,7 +40,7 @@ test('Test productUserResource2PartyUser', () => {
     status: 'PENDING',
     userRole: 'LIMITED',
     email: 'address',
-    excludeRoleFromUserGroups: undefined,
+    excludeRoleFromUserGroups: true,
     product: {
       id: 'productId',
       title: 'productTitle',

--- a/src/model/__tests__/PartyUser.test.ts
+++ b/src/model/__tests__/PartyUser.test.ts
@@ -52,6 +52,7 @@ test('Test productUserResource2PartyUser', () => {
       ],
     },
     isCurrentUser: false,
+    excludeRoleFromUserGroups: undefined,
   });
 
   productUserResource.id = mockedUser.uid;

--- a/src/pages/dashboardGroupEdit/components/GroupForm.tsx
+++ b/src/pages/dashboardGroupEdit/components/GroupForm.tsx
@@ -131,6 +131,7 @@ function GroupForm({
   const [automaticRemove, setAutomaticRemove] = useState(false);
   const [isNameDuplicated, setIsNameDuplicated] = useState(false);
   const [productInPage, setProductInPage] = useState<boolean>();
+  const [hasExcludedUsers, setHasExcludedUsers] = useState(false);
 
   const { hasPermission } = usePermissions();
   const { announce, LiveRegion } = useLiveAnnouncerWithRegion();
@@ -334,6 +335,25 @@ function GroupForm({
   const containsInitialUsers = (productUsers: Array<PartyProductUser>) =>
     initialFormData.members.every((u) => productUsers.find((p) => p.id === u.id));
 
+  const initializeFormMembers = (filteredUsers: Array<PartyProductUser>) => {
+    if (!isEdit && !isClone) {
+      void formik.setFieldValue('members', [], true);
+    } else if (isEdit) {
+      void formik.setFieldValue('members', (initialFormData as PartyGroupOnEdit).members, true);
+    } else if (isClone) {
+      const selectedIds = formik.values.members.reduce((acc, u) => {
+        // eslint-disable-next-line functional/immutable-data
+        acc[u.id] = true;
+        return acc;
+      }, {} as { [userId: string]: boolean });
+      const nextMembers = filteredUsers.filter((u) => selectedIds[u.id]);
+      if (!containsInitialUsers(nextMembers)) {
+        setAutomaticRemove(true);
+      }
+      void formik.setFieldValue('members', nextMembers, true);
+    }
+  };
+
   const fetchProductUsers = (productSelected: Product) => {
     setLoadingFetchUserProduct(true);
     fetchPartyProductUsers(
@@ -345,29 +365,25 @@ function GroupForm({
       []
     )
       .then((productUsersPage) => {
-        // suspended users have to be listed
-        // setProductUsers(productUsersPage.content.filter((user) => user.status === 'ACTIVE')); // the status should be evaluated from user.products[current Product].status
-        const sortedProductUsers = productUsersPage.content
-          ? [...productUsersPage.content].sort((a, b) => a.name.localeCompare(b.name))
-          : [];
+        const contentUsers = productUsersPage.content ? [...productUsersPage.content] : [];
+        const filteredUsers =
+          productSelected.id === 'prod-io'
+            ? contentUsers.filter((u) => !u.excludeRoleFromUserGroups)
+            : contentUsers;
+
+        if (productSelected.id === 'prod-io') {
+          const excludedUsersCount = contentUsers.filter((u) => u.excludeRoleFromUserGroups).length;
+          setHasExcludedUsers(excludedUsersCount > 0);
+        } else {
+          setHasExcludedUsers(false);
+        }
+
+        const sortedProductUsers = [...filteredUsers].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        );
 
         setProductUsers(sortedProductUsers);
-        if (!isEdit && !isClone) {
-          void formik.setFieldValue('members', [], true);
-        } else if (isEdit) {
-          void formik.setFieldValue('members', (initialFormData as PartyGroupOnEdit).members, true);
-        } else if (isClone) {
-          const selectedIds = formik.values.members.reduce((acc, u) => {
-            // eslint-disable-next-line functional/immutable-data
-            acc[u.id] = true;
-            return acc;
-          }, {} as { [userId: string]: boolean });
-          const nextMembers = productUsersPage.content.filter((u) => selectedIds[u.id]);
-          if (!containsInitialUsers(nextMembers)) {
-            setAutomaticRemove(true);
-          }
-          void formik.setFieldValue('members', nextMembers, true);
-        }
+        initializeFormMembers(filteredUsers);
       })
       .catch((reason) =>
         addError({
@@ -663,6 +679,11 @@ function GroupForm({
               />
             ))}
           </Grid>
+          {hasExcludedUsers && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              {t('dashboardGroupEdit.groupForm.formLabels.excludedUsersHelperText')}
+            </Typography>
+          )}
         </Grid>
 
         {/* Actions */}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
exclude adding users from aggregators with prod io
localize the new helper text
<!--- Describe your changes in detail -->

#### Motivation and Context
Not allow admin_ea users to be added to ordinary groups of the aggregate only the autamatic one created guring onboarding.
<!--- Why is this change required? What problem does it solve? -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.